### PR TITLE
repo: Use https instead of unencrypted git protocol for repourl

### DIFF
--- a/repo
+++ b/repo
@@ -20,7 +20,7 @@ URL=""
 LOCKFILE=service_lockfile
 LOCK="$SVCDIR/repo/$LOCKFILE" # It does not need to be in $STORE.
 repocmd=/usr/bin/repo
-repourl="--repo-url=git://github.com/mer-tools/git-repo.git --no-repo-verify"
+repourl="--repo-url=https://github.com/mer-tools/git-repo.git --no-repo-verify"
 SHA1ONLY=no
 MANIFEST_NAME=default.xml
 MANIFEST=.repo/manifests/$MANIFEST_NAME


### PR DESCRIPTION
Github disabled the support of the unencrypted git:// protocol recently.

https://github.blog/2021-09-01-improving-git-protocol-security-github/